### PR TITLE
Refactor test setup to use testingLibrarySetup.js

### DIFF
--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,6 +1,0 @@
-import { configure } from '@testing-library/react'
-
-// See vite.config.js for the test environment setup
-import '@testing-library/jest-dom' // For DOM assertions like `.toBeInTheDocument()`
-
-configure({ testIdAttribute: 'data-cy' })

--- a/src/store/slices/authenticationSlice.test.js
+++ b/src/store/slices/authenticationSlice.test.js
@@ -18,7 +18,7 @@ import authenticationReducer, {
 	authActions,
 } from './authenticationSlice'
 
-import { setupMocks } from '@/testUtils/vitest/testSetup'
+import { setupMocks } from '@/testUtils/vitest/testingLibrarySetup'
 
 vi.mock('@/constants/api', () => ({
 	API_DATABASE: {

--- a/src/store/slices/travellersSlice.test.js
+++ b/src/store/slices/travellersSlice.test.js
@@ -15,7 +15,7 @@ import travellersReducer, {
 
 import { handleApiError } from '@/utils/errorHandler'
 
-import { setupMocks } from '@/testUtils/vitest/testSetup'
+import { setupMocks } from '@/testUtils/vitest/testingLibrarySetup'
 
 vi.mock('@/constants/api', () => ({
 	API_DATABASE: {

--- a/src/testUtils/vitest/testingLibrarySetup.js
+++ b/src/testUtils/vitest/testingLibrarySetup.js
@@ -1,5 +1,11 @@
+import { configure } from '@testing-library/react'
 import { vi } from 'vitest'
+import '@testing-library/jest-dom'
 
+// Configure testing library
+configure({ testIdAttribute: 'data-cy' })
+
+// Setup mocks
 export const setupMocks = () => {
 	global.fetch = vi.fn()
 
@@ -13,3 +19,6 @@ export const setupMocks = () => {
 		writable: true,
 	})
 }
+
+// Auto-run mocks setup
+setupMocks()

--- a/vite.config.js
+++ b/vite.config.js
@@ -83,7 +83,7 @@ export default defineConfig({
 	test: {
 		globals: true,
 		environment: 'jsdom',
-		setupFiles: './src/setupTests.js',
+		setupFiles: './src/testUtils/vitest/testingLibrarySetup.js',
 		coverage: {
 			provider: 'v8',
 			reportsDirectory: './coverage',


### PR DESCRIPTION
- Removed src/setupTests.js and consolidated test setup into src/testUtils/vitest/testingLibrarySetup.js.
- Updated imports in test files and vite.config.js to reference the new setup file.

This change centralises and streamlines test environment configuration, and removes confusion with similar file names.