### PR TITLE
Add @vercel/speed-insights for performance monitoring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"dependencies": {
 				"@reduxjs/toolkit": "^2.8.2",
 				"@vercel/analytics": "^1.5.0",
+				"@vercel/speed-insights": "^1.2.0",
 				"classnames": "^2.5.1",
 				"firebase": "^12.1.0",
 				"prop-types": "^15.8.1",
@@ -3381,6 +3382,41 @@
 				"@remix-run/react": {
 					"optional": true
 				},
+				"@sveltejs/kit": {
+					"optional": true
+				},
+				"next": {
+					"optional": true
+				},
+				"react": {
+					"optional": true
+				},
+				"svelte": {
+					"optional": true
+				},
+				"vue": {
+					"optional": true
+				},
+				"vue-router": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vercel/speed-insights": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-1.2.0.tgz",
+			"integrity": "sha512-y9GVzrUJ2xmgtQlzFP2KhVRoCglwfRQgjyfY607aU0hh0Un6d0OUyrJkjuAlsV18qR4zfoFPs/BiIj9YDS6Wzw==",
+			"hasInstallScript": true,
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"@sveltejs/kit": "^1 || ^2",
+				"next": ">= 13",
+				"react": "^18 || ^19 || ^19.0.0-rc",
+				"svelte": ">= 4",
+				"vue": "^3",
+				"vue-router": "^4"
+			},
+			"peerDependenciesMeta": {
 				"@sveltejs/kit": {
 					"optional": true
 				},

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 	"dependencies": {
 		"@reduxjs/toolkit": "^2.8.2",
 		"@vercel/analytics": "^1.5.0",
+		"@vercel/speed-insights": "^1.2.0",
 		"classnames": "^2.5.1",
 		"firebase": "^12.1.0",
 		"prop-types": "^15.8.1",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,7 +1,5 @@
-import { inject } from '@vercel/speed-insights/react'
+import { SpeedInsights } from '@vercel/speed-insights/react'
 import { Analytics } from '@vercel/analytics/react'
-
-inject()
 
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
@@ -17,6 +15,7 @@ createRoot(document.getElementById('app')).render(
 		<Provider store={store}>
 			<App />
 			<Analytics />
+			<SpeedInsights />
 		</Provider>
 	</StrictMode>,
 )

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,4 +1,7 @@
+import { inject } from '@vercel/speed-insights/react'
 import { Analytics } from '@vercel/analytics/react'
+
+inject()
 
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'

--- a/vite.config.js
+++ b/vite.config.js
@@ -76,6 +76,7 @@ export default defineConfig({
 					router: ['react-router-dom'],
 					firebase: ['firebase/app'],
 					analytics: ['@vercel/analytics'],
+					speedInsights: ['@vercel/speed-insights'],
 					transition: ['react-transition-group'],
 				},
 			},


### PR DESCRIPTION
- Installed @vercel/speed-insights and integrated it into the React app by calling inject() in index.jsx.
- Updated vite.config.js to include speedInsights in the vendor chunk. This enables performance insights for the application.