### PR TITLE
Pin Cypress GitHub Action to specific commit

### DIFF
--- a/.github/workflows/cypress-component.yml
+++ b/.github/workflows/cypress-component.yml
@@ -34,7 +34,7 @@ jobs:
               run: npm ci
 
             - name: Run Cypress Component Tests
-              uses: cypress-io/github-action@v6
+              uses: cypress-io/github-action@b8ba51a856ba5f4c15cf39007636d4ab04f23e3c # v6.10.2 #1507
               with:
                   component: true
 

--- a/.github/workflows/cypress-e2e.yml
+++ b/.github/workflows/cypress-e2e.yml
@@ -56,7 +56,7 @@ jobs:
               run: npm ci
 
             - name: Start app & run Cypress E2E Page Tests
-              uses: cypress-io/github-action@v6
+              uses: cypress-io/github-action@b8ba51a856ba5f4c15cf39007636d4ab04f23e3c # v6.10.2 #1507
               env:
                   VITE_API_URL: ${{ secrets.VITE_API_URL }}
                   VITE_API_KEY: ${{ secrets.VITE_API_KEY }}


### PR DESCRIPTION
Updated Cypress GitHub Action in component and e2e workflows to use a specific commit (b8ba51a856ba5f4c15cf39007636d4ab04f23e3c) for improved reliability and reproducibility. This change ensures the workflows use v6.10.2 as referenced in #1507.