### PR TITLE
Add permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/cypress-component.yml
+++ b/.github/workflows/cypress-component.yml
@@ -1,4 +1,7 @@
 name: Cypress - Run Component Tests
+permissions:
+    contents: read
+    pull-requests: write
 
 on:
     push:

--- a/.github/workflows/cypress-e2e.yml
+++ b/.github/workflows/cypress-e2e.yml
@@ -1,4 +1,7 @@
 name: Cypress - Run E2E Page Tests
+permissions:
+    contents: read
+    pull-requests: write
 
 on:
     push:

--- a/.github/workflows/vitest-unit-tests.yml
+++ b/.github/workflows/vitest-unit-tests.yml
@@ -1,4 +1,7 @@
 name: Vitest - Run Unit Tests
+permissions:
+    contents: read
+    pull-requests: write
 
 on:
     push:


### PR DESCRIPTION
Explicitly set 'contents: read' and 'pull-requests: write' permissions in Cypress component, Cypress E2E, and Vitest unit test workflows to improve security and clarify required access.