### PR TITLE
Add tests for sectionClasses prop in BaseDialog

### DIFF
--- a/src/components/ui/dialog/__tests__/BaseDialog.test.jsx
+++ b/src/components/ui/dialog/__tests__/BaseDialog.test.jsx
@@ -14,6 +14,14 @@ import { DIALOG } from '@/constants/test/dialog'
  * - Ensures prop spreading and custom class handling via sectionClasses
  */
 
+// Mock CSS Modules
+vi.mock('@/components/ui/dialog/BaseDialog.module.scss', () => ({
+	default: {
+		image: 'image',
+		general: 'general',
+	},
+}))
+
 // Mock react-dom before importing the component
 vi.mock('react-dom', async () => {
 	const actual = await vi.importActual('react-dom')
@@ -105,6 +113,24 @@ describe('<BaseDialog />', () => {
 			renderDialog()
 			fireEvent.keyDown(window, { key: 'Escape' })
 			expect(defaultProps.onClose).toHaveBeenCalled()
+		})
+
+		it('applies image class when sectionClasses is true', () => {
+			renderDialog({ sectionClasses: true })
+			const mainElement = screen.getByTestId(DIALOG.TEXT_CONTENT)
+			expect(mainElement).toHaveClass('image')
+		})
+
+		it('applies general class when sectionClasses is false', () => {
+			renderDialog({ sectionClasses: false })
+			const mainElement = screen.getByTestId(DIALOG.TEXT_CONTENT)
+			expect(mainElement).toHaveClass('general')
+		})
+
+		it('applies general class when sectionClasses is not provided (default)', () => {
+			renderDialog()
+			const mainElement = screen.getByTestId(DIALOG.TEXT_CONTENT)
+			expect(mainElement).toHaveClass('general')
 		})
 	})
 


### PR DESCRIPTION
- Added unit tests to verify that the correct CSS class is applied to the dialog content based on the sectionClasses prop value.
- Mocked CSS modules to ensure consistent class names in tests.